### PR TITLE
11 create production build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": ["env"]
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": "current"
+      }
+    }]
+  ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage
 
 # production
 build
+dist
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "sequelize-cli": "^3.2.0"
   },
   "scripts": {
-    "start": "nodemon --exec babel-node src/server.js"
+    "start": "nodemon --exec babel-node src/server.js",
+    "build": "babel src -d dist",
+    "serve": "node dist/server.js"
   }
 }


### PR DESCRIPTION
Closes #11 

Add production build for node to package.json and update babelrc target to current node version.
This will keep let and const and arrow functions and etc.
And ignore the build output folder, dist.
